### PR TITLE
Feature Request : Add ability to specify query and hit fasta files as command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Several lines of status information will be written to the console during progra
 After program has finished the results files will be located in the same folder as the first database. The results files will be two files with “.xml” and “.txt” extensions. The filename will be a combination of the query and hit database names. The XML file is the full results from the BLAST run, including alignments and all hits per query. The TXT file is a tab-delimited summary of the top matches that shows query protein accession and description, top-matching hit accession and description, BLAST scores, and status information.
 
 ### Command Line Arguments
-* For developer/scripting use *
+_For developer/scripting use_
 
 `db_to_db_blaster.py` accepts two optional command line arguments specifying fasta files to use. If fasta files are specified in the command line, user is not prompted to select files via the file dialog. 
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The scripts can be launched in a few ways. The program’s icon can be double cl
 Program logic is simple. It takes every sequence in the first database (called the query database) and performs BLAST alignments to all proteins in a second database (called the hit database). The databases should be protein sequences in FASTA format. The databases will be converted to BLAST formatted files (3 files with extensions of “.phr”, “.pin”, and “.psq”). If those files exist, the database conversion is skipped to save time. Be warned that BLAST may not like valid FASTA characters such as stop codons (*) or gaps (-) and input databases may need to be processed to remove such characters. The BLAST run is saved in a (large) XML file and may take several hours to complete. If the XML file already exists, the BLAST run is skipped. If the BLAST run needs to be repeated make sure the XML file is deleted before running `db_to_db_blaster.py`. After the BLAST run has finished, the XML file is parsed and the top-matching hit protein for each query protein is reported in a tab-delimited text file that can be opened with Excel or any text editor. Details about the output file contents are given below.
 
 ## Program Execution
+ 
 When the program starts, a dialog box will ask the user to browse to the first (query) database file:
 
 ![first FASTA](images/first_FASTA.png)
@@ -65,6 +66,16 @@ Several lines of status information will be written to the console during progra
 ![console output](images/console.png)
 
 After program has finished the results files will be located in the same folder as the first database. The results files will be two files with “.xml” and “.txt” extensions. The filename will be a combination of the query and hit database names. The XML file is the full results from the BLAST run, including alignments and all hits per query. The TXT file is a tab-delimited summary of the top matches that shows query protein accession and description, top-matching hit accession and description, BLAST scores, and status information.
+
+### Command Line Arguments
+* For developer/scripting use *
+
+`db_to_db_blaster.py` accepts two optional command line arguments specifying fasta files to use. If fasta files are specified in the command line, user is not prompted to select files via the file dialog. 
+
+**Usage**
+```python
+usage : db_to_db_blaster.py [query_db.fasta hit_db.fasta]
+```
 
 ## Database Definitions
 

--- a/db_to_db_blaster.py
+++ b/db_to_db_blaster.py
@@ -493,6 +493,56 @@ def better_match_check(results):
                 q.status = 'Better_match to %s' % best_score[h_acc][1]
         except IndexError:
             pass
+
+def validate_fasta_file(file):
+    valid = True
+    # if the file does not exist - bad user input
+    if not os.path.exists(file):
+        print(file, 'does not exist')
+        valid = False
+    # if the user specified a file with type other than fasta
+    elif not file.endswith('.fasta'):
+        print(os.path.basename(file), 'is not a fasta file')
+        valid = False
+
+    # if the file is not valid, print the command line usage and exit
+    if not valid:
+        print_cmd_file_args_usage()
+        sys.exit()
+
+def print_cmd_file_args_usage():
+    print('\n----')
+    print('usage : db_to_db_blaster.py [query_db.fasta hit_db.fasta]')
+
+def use_cmd_args_databases():
+    # first argument is the query database
+    first_db = sys.argv[1]
+    validate_fasta_file(first_db)
+    # second argument is hit database
+    second_db = sys.argv[2]
+    validate_fasta_file(second_db)
+
+    return (first_db, second_db)
+
+
+def select_databases_from_dialog():
+    # get the two PAW results databases to blast against each other
+    if os.path.exists(r'C:\Xcalibur\database'):
+        default = r'C:\Xcalibur\database'
+    else:
+        default = os.getcwd()
+
+    print('Select first FASTA file')
+    first_db = get_file(default, [('FASTA files', '*.fasta')],\
+                                    'Select first database')
+    if not first_db: sys.exit()     # cancel button was hit
+    default = os.path.dirname(first_db)
+    print('Select the second FASTA file')
+    second_db = get_file(default, [('FASTA files', '*.fasta')],\
+                                    'Select second database')
+    if not second_db: sys.exit()    # cancel button was hit
+
+    return (first_db, second_db)
        
 #==============================================================        
 # MAIN program to call local copy of blastp
@@ -506,21 +556,12 @@ print('\n=====================================================================')
 print(' program "db_to_db_blaster.py", v1.1, Phil Wilmarth, OHSU, 2011, 2017')
 print('=====================================================================')
 
-# get the two PAW results databases to blast against each other
-if os.path.exists(r'C:\Xcalibur\database'):
-    default = r'C:\Xcalibur\database'
+# if query and hit databases have been specified as cmd args
+if 3 == len(sys.argv):
+    first_db, second_db = use_cmd_args_databases()
+# otherwise, prompt the user for files using the dialog
 else:
-    default = os.getcwd()
-
-print('Select first FASTA file')
-first_db = get_file(default, [('FASTA files', '*.fasta')],\
-                                'Select first database')
-if not first_db: sys.exit()     # cancel button was hit
-default = os.path.dirname(first_db)
-print('Select the second FASTA file')
-second_db = get_file(default, [('FASTA files', '*.fasta')],\
-                                'Select second database')
-if not second_db: sys.exit()    # cancel button was hit
+    first_db, second_db = select_databases_from_dialog()
 
 # echo database names to console output
 print('Query database:', os.path.basename(first_db))


### PR DESCRIPTION
## Feature Request
Add ability to specify query and hit fasta files as command line arguments

For background : currently working on web hosted instance of this tool at : https://github.com/Anderson-Lab/compare_web. For this we would like to be able to kick off jobs using the `db_to_db_blaster.py` script without user input.